### PR TITLE
Add configurable random flipping augmentation

### DIFF
--- a/configs/default_josh_config.py
+++ b/configs/default_josh_config.py
@@ -63,7 +63,7 @@ def get_default_configs():
     data.dataset = 'UKCP_Local'
     data.dataset_name = 'ERA5_IMERG_Med_192x192_2000-2024_indiv_seasons' #'bham64_ccpm-4x_1em_psl-sphum4th-temp4th-vort4th_pr'
     data.image_size = 192
-    data.random_flip = False
+    data.random_flip = False  # Enable random horizontal/vertical flips during training
     data.centered = False
     data.uniform_dequantization = False
     data.input_transform_dataset = None

--- a/src/data_scripts/collate_np_per_var/custom_collate.py
+++ b/src/data_scripts/collate_np_per_var/custom_collate.py
@@ -7,6 +7,7 @@ import logging
 import numpy as np
 import torch
 import torch.distributed as dist
+from torchvision.transforms import functional as TF
 
 logger = logging.getLogger()
 
@@ -27,7 +28,8 @@ class FastCollate:
             target_transforms=None,
             time_range=None,
             input_variable_order=None,
-            target_variable_order=None
+            target_variable_order=None,
+            random_flip=False,
         ):
         # expected: input_transforms is either None or dict: {var: transform_obj}
         self.input_transforms = input_transforms
@@ -36,6 +38,7 @@ class FastCollate:
         # allow user override of variable order; otherwise deduce from input_transforms or the first batch
         self.input_variable_order = list(input_variable_order) if input_variable_order is not None else None
         self.target_variable_order = list(target_variable_order) if target_variable_order is not None else None
+        self.random_flip = random_flip
 
     def _apply_transform_safe(self, xfm, arr):
         """
@@ -209,5 +212,14 @@ class FastCollate:
             # final conversion to torch
             conds_t = torch.from_numpy(conds)
             targs_t = torch.from_numpy(targs)
+
+            if self.random_flip:
+                if torch.rand(1) < 0.5:
+                    conds_t = TF.hflip(conds_t)
+                    targs_t = TF.hflip(targs_t)
+                if torch.rand(1) < 0.5:
+                    conds_t = TF.vflip(conds_t)
+                    targs_t = TF.vflip(targs_t)
+
             times = np.array([b[2] for b in batch])
             return conds_t, targs_t, times

--- a/src/data_scripts/collate_np_per_var/data_module.py
+++ b/src/data_scripts/collate_np_per_var/data_module.py
@@ -132,10 +132,16 @@ class LightningDataModule(pl.LightningDataModule):
             )
             self.val_len = _get_zarr_length(self.val_zarr_path)
 
-            self.dl_kwargs['collate_fn'] = FastCollate(
+            self.train_collate = FastCollate(
                 input_transforms=self.train_transforms,
                 target_transforms=self.train_target_transforms,
-                time_range=self.time_range
+                time_range=self.time_range,
+                random_flip=self.config.data.random_flip,
+            )
+            self.val_collate = FastCollate(
+                input_transforms=self.train_transforms,
+                target_transforms=self.train_target_transforms,
+                time_range=self.time_range,
             )
 
 
@@ -155,10 +161,10 @@ class LightningDataModule(pl.LightningDataModule):
             self.test_len = _get_zarr_length(self.test_zarr_path)
             print(" >> >> INSIDE data_module setup <<TEST>> zarr_len =", self.test_len)
 
-            self.dl_kwargs['collate_fn'] = FastCollate(
+            self.test_collate = FastCollate(
                 input_transforms=self.test_transforms,
                 target_transforms=self.test_target_transforms,
-                time_range=self.time_range
+                time_range=self.time_range,
             )
 
     def train_dataloader(self):
@@ -181,8 +187,9 @@ class LightningDataModule(pl.LightningDataModule):
             self.train_len
         )
 
+        self.dl_kwargs['collate_fn'] = getattr(self, "train_collate", self.dl_kwargs.get('collate_fn'))
         data_loader = DataLoader(xr_dataset, **self.dl_kwargs)
-        
+
         return data_loader
 
     def val_dataloader(self):
@@ -195,9 +202,10 @@ class LightningDataModule(pl.LightningDataModule):
         )
 
         self.dl_kwargs['shuffle'] = False
-        
+        self.dl_kwargs['collate_fn'] = getattr(self, "val_collate", self.dl_kwargs.get('collate_fn'))
+
         data_loader = DataLoader(xr_dataset, **self.dl_kwargs)
-        
+
         return data_loader
 
     def test_dataloader(self):
@@ -211,6 +219,7 @@ class LightningDataModule(pl.LightningDataModule):
 
         self.dl_kwargs['num_workers'] = 0
         self.dl_kwargs['shuffle'] = False
+        self.dl_kwargs['collate_fn'] = getattr(self, "test_collate", self.dl_kwargs.get('collate_fn'))
 
         data_loader = DataLoader(xr_dataset, **self.dl_kwargs)
         


### PR DESCRIPTION
## Summary
- document the random flip configuration toggle in the default config
- add optional tensor-based horizontal and vertical flips in the training collate
- ensure validation and test dataloaders retain non-augmented collate functions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ac563195c8324a05b4336b26cec2a)