### PR TITLE
Add Doury (2024) ASYM loss; default gamma fitting to ML training file

### DIFF
--- a/configs/default_josh_config.py
+++ b/configs/default_josh_config.py
@@ -23,10 +23,16 @@ def get_default_configs():
     training.continuous = True
     training.reduce_mean = False
     training.random_crop_size = 0
-    training.det_loss_type = '' # Use WMSE_MS-SSIM for weighted-MSE loss. MUST USE data.predictands.target_transform_keys = ["none"]
+    training.det_loss_type = '' # Options: 'WMSE_MS-SSIM', 'ASYM'. MUST USE data.predictands.target_transform_keys = ["none"]
     training.wmse_ms_ssim_alpha = 0.1
     training.wmse_ms_ssim_beta = 0.15
     training.wmse_ms_ssim_lam = 0.1
+    # Doury et al. (2024) ASYM loss settings
+    training.asym_train_filename = ''   # zarr filename for gamma fitting (e.g. 'train_summer.zarr').
+                                        # Leave empty to reuse the ML training file (FLAGS.filename).
+    training.asym_rain_threshold = 1.0  # wet-day threshold (same units as data, e.g. mm/hr)
+    training.asym_lat_chunk = 16        # spatial tile size (lat) for gamma fitting
+    training.asym_lon_chunk = 16        # spatial tile size (lon) for gamma fitting
 
     # model
     config.model = model = ml_collections.ConfigDict()

--- a/src/losses.py
+++ b/src/losses.py
@@ -20,10 +20,12 @@
 """All functions related to loss computation and optimization.
 """
 
+import os
 import torch
 import torch.nn.functional as F
 import numpy as np
 import logging
+from pathlib import Path
 from pytorch_msssim import ms_ssim
 
 logger = logging.getLogger(__name__)
@@ -196,6 +198,276 @@ def get_deterministic_loss_fn_wmse_msssim(
 
     return loss_fn
 #====================================================================
+def fit_gamma_params_per_gridpoint(
+    precip_data,
+    precip_var='precipitation',
+    rain_threshold=1.0,
+    lat_chunk=16,
+    lon_chunk=16,
+    min_rainy_days=10,
+):
+    """Fit Gamma(shape, scale) at each grid point on rainy-day values.
+
+    Designed for large (tens of GB) dask-backed precipitation DataArrays.
+    Data is rechunked to (time=-1, lat_chunk, lon_chunk) tiles for fitting;
+    the original DataArray passed in is never mutated.
+
+    Args:
+        precip_data: One of:
+            - str/Path    : path to a zarr or NetCDF file
+            - xr.DataArray: dask-backed or in-memory array (time, lat, lon)
+            - xr.Dataset  : dataset; ``precip_var`` is extracted
+            - np.ndarray  : shape (T, H, W)
+        precip_var: Variable name if ``precip_data`` is a file path or Dataset.
+        rain_threshold: Wet-day threshold (same units as data).
+        lat_chunk: Spatial tile size in the latitude dimension.
+        lon_chunk: Spatial tile size in the longitude dimension.
+        min_rainy_days: Minimum rainy samples required for a proper fit;
+            grid points with fewer samples fall back to Exponential(shape=1).
+
+    Returns:
+        shape_map: np.ndarray [H, W] of Gamma shape parameters.
+        scale_map: np.ndarray [H, W] of Gamma scale parameters.
+    """
+    import xarray as xr
+    import scipy.stats
+    from tqdm import tqdm
+
+    # --- Load / prepare DataArray ---
+    if isinstance(precip_data, (str, Path)):
+        p = Path(precip_data)
+        if p.suffix == '.zarr' or p.is_dir():
+            ds = xr.open_zarr(str(p))
+        else:
+            ds = xr.open_dataset(str(p), chunks='auto')
+        da = ds[precip_var]
+    elif isinstance(precip_data, xr.Dataset):
+        da = precip_data[precip_var]
+    elif isinstance(precip_data, xr.DataArray):
+        da = precip_data
+    elif isinstance(precip_data, np.ndarray):
+        da = xr.DataArray(precip_data, dims=['time', 'lat', 'lon'])
+    else:
+        raise TypeError(f"Unsupported type for precip_data: {type(precip_data)}")
+
+    dims     = list(da.dims)
+    time_dim = dims[0]
+    lat_dim  = dims[1]
+    lon_dim  = dims[2]
+    H = da.sizes[lat_dim]
+    W = da.sizes[lon_dim]
+
+    # --- Spin up LocalCluster for parallel tile IO ---
+    client  = None
+    cluster = None
+    try:
+        from dask.distributed import LocalCluster, Client
+        n_workers = max(1, os.cpu_count() or 1)
+        print(f"[fit_gamma] Starting LocalCluster with {n_workers} worker(s)...")
+        cluster = LocalCluster(n_workers=n_workers, threads_per_worker=1, memory_limit='4GB')
+        client  = Client(cluster)
+        print(f"[fit_gamma] Dashboard: {client.dashboard_link}")
+    except ImportError:
+        print("[fit_gamma] dask.distributed not available; using synchronous scheduler")
+
+    # --- Rechunk for fitting: full time axis, small spatial tiles ---
+    da_fit = da.chunk({time_dim: -1, lat_dim: lat_chunk, lon_dim: lon_chunk})
+
+    # --- Allocate output ---
+    shape_map    = np.ones((H, W), dtype=np.float32)
+    scale_map    = np.ones((H, W), dtype=np.float32)
+    fallback_cnt = 0
+
+    n_lat_tiles = (H + lat_chunk - 1) // lat_chunk
+    n_lon_tiles = (W + lon_chunk - 1) // lon_chunk
+    n_tiles     = n_lat_tiles * n_lon_tiles
+
+    with tqdm(total=n_tiles, desc="Tiles loaded", unit="tile") as tile_pbar:
+        with tqdm(total=H * W, desc="Gridpoints fitted", unit="pt") as pt_pbar:
+            for i0 in range(0, H, lat_chunk):
+                i1 = min(i0 + lat_chunk, H)
+                for j0 in range(0, W, lon_chunk):
+                    j1 = min(j0 + lon_chunk, W)
+
+                    # Compute tile (triggers dask IO, parallelised by LocalCluster)
+                    tile = da_fit.isel(
+                        {lat_dim: slice(i0, i1), lon_dim: slice(j0, j1)}
+                    ).values  # [T, tile_h, tile_w]
+
+                    tile_h = i1 - i0
+                    tile_w = j1 - j0
+
+                    with tqdm(
+                        total=tile_h * tile_w,
+                        desc=f"Rows {i0}-{i1}",
+                        leave=False,
+                        unit="pt",
+                    ) as inner_pbar:
+                        for ii in range(tile_h):
+                            for jj in range(tile_w):
+                                series = tile[:, ii, jj].astype(np.float64)
+                                rainy  = series[series > rain_threshold]
+                                gi, gj = i0 + ii, j0 + jj
+
+                                if len(rainy) >= min_rainy_days:
+                                    try:
+                                        shp, _, scl = scipy.stats.gamma.fit(rainy, floc=0)
+                                        shape_map[gi, gj] = max(float(shp), 1e-6)
+                                        scale_map[gi, gj] = max(float(scl), 1e-6)
+                                    except Exception:
+                                        shape_map[gi, gj] = 1.0
+                                        scale_map[gi, gj] = max(float(np.mean(rainy)), 1e-6)
+                                        fallback_cnt += 1
+                                else:
+                                    shape_map[gi, gj] = 1.0
+                                    scale_map[gi, gj] = max(
+                                        float(np.mean(rainy)) if len(rainy) > 0 else 1.0,
+                                        1e-6,
+                                    )
+                                    fallback_cnt += 1
+
+                                inner_pbar.update(1)
+                                pt_pbar.update(1)
+
+                    tile_pbar.update(1)
+
+    if client is not None:
+        client.close()
+        cluster.close()
+
+    total = H * W
+    print(f"\n[fit_gamma] Complete — {total} gridpoints | "
+          f"fitted: {total - fallback_cnt} | fallbacks: {fallback_cnt}")
+    print(f"[fit_gamma] shape: min={shape_map.min():.4f} max={shape_map.max():.4f} "
+          f"mean={shape_map.mean():.4f}")
+    print(f"[fit_gamma] scale: min={scale_map.min():.4f} max={scale_map.max():.4f} "
+          f"mean={scale_map.mean():.4f}")
+
+    return shape_map, scale_map
+#====================================================================
+def get_deterministic_loss_fn_asym_doury(
+    train,
+    gamma_shape,
+    gamma_scale,
+    rain_threshold=1.0,
+    reduce_mean=True,
+):
+    """Doury et al. (2024) asymmetric precipitation loss (Eq. 4).
+
+    L(y, ŷ) = mean( |y - ŷ|  +  γ²_{i,t} · max(0, y_{i,t} - ŷ_{i,t}) )
+
+    where γ_{i,t} = G_i(y_{i,t}) is the per-gridpoint Gamma CDF evaluated
+    at the true precipitation value.  The asymmetric term fires only when
+    the model underestimates a rainy pixel, with a penalty proportional to
+    the rarity of that rainfall intensity.
+
+    The model must be trained in physical units (target_transform_keys='none').
+
+    Args:
+        train: Unused; kept for API compatibility.
+        gamma_shape: [H, W] numpy array of fitted Gamma shape parameters.
+        gamma_scale: [H, W] numpy array of fitted Gamma scale parameters.
+        rain_threshold: Wet-day threshold (same units as data).
+            Dry pixels (y ≤ threshold) have the asymmetric term zeroed.
+        reduce_mean: If True, average loss over all elements.
+
+    Returns:
+        A loss_fn(model, batch, cond, generator=None) callable.
+    """
+    gamma_shape_np = np.asarray(gamma_shape, dtype=np.float32)
+    gamma_scale_np = np.asarray(gamma_scale, dtype=np.float32)
+
+    if is_main_process():
+        logger.info(
+            "[asym_doury] loss initialised | rain_threshold=%.3f | "
+            "shape mean=%.4f | scale mean=%.4f",
+            rain_threshold,
+            gamma_shape_np.mean(),
+            gamma_scale_np.mean(),
+        )
+
+    # Cache tensors per device to avoid re-creating every step
+    _cache = {"device": None, "shape_t": None, "scale_t": None}
+    call_state = {"n": 0}
+
+    def loss_fn(model, batch, cond, generator=None):
+        call_state["n"] += 1
+        device = batch.device
+
+        if _cache["device"] != device:
+            _cache["shape_t"] = torch.tensor(gamma_shape_np, device=device)
+            _cache["scale_t"] = torch.tensor(gamma_scale_np, device=device)
+            _cache["device"]  = device
+
+        shape_t = _cache["shape_t"]
+        scale_t = _cache["scale_t"]
+
+        # Deterministic model: x=0, t=0
+        x    = torch.zeros_like(batch)
+        t    = torch.zeros(batch.shape[0], device=device)
+        pred = model(x, cond, t)
+
+        target_phys = batch
+        pred_phys   = pred
+
+        # --- Per-gridpoint Gamma CDF (no gradient needed — applied to target) ---
+        # CDF of Gamma(shape, scale) at y = gammainc(shape, y/scale)
+        with torch.no_grad():
+            target_safe = torch.clamp(target_phys, min=0.0)
+
+            if target_phys.ndim == 4:          # [B, C, H, W]
+                shape_exp = shape_t.unsqueeze(0).unsqueeze(0)
+                scale_exp = scale_t.unsqueeze(0).unsqueeze(0)
+            else:                              # [B, H, W]
+                shape_exp = shape_t.unsqueeze(0)
+                scale_exp = scale_t.unsqueeze(0)
+
+            gamma_cdf = torch.special.gammainc(
+                shape_exp,
+                target_safe / scale_exp.clamp(min=1e-8),
+            )
+            # Zero asymmetric term on dry pixels
+            rainy_mask = (target_phys > rain_threshold).float()
+            gamma_cdf  = gamma_cdf * rainy_mask
+
+        # --- MAE term ---
+        mae = torch.abs(target_phys - pred_phys)
+
+        # --- Asymmetric term: γ² · max(0, y - ŷ) ---
+        underest = torch.clamp(target_phys - pred_phys, min=0.0)
+        asym     = gamma_cdf ** 2 * underest
+
+        total = mae + asym
+
+        # --- Reduce ---
+        if reduce_mean:
+            loss     = torch.mean(total)
+            mae_val  = torch.mean(mae)
+            asym_val = torch.mean(asym)
+        else:
+            if total.ndim == 4:
+                sdims = (1, 2, 3)
+            elif total.ndim == 3:
+                sdims = (1, 2)
+            else:
+                sdims = tuple(range(1, total.ndim))
+            loss     = total.mean(dim=sdims).mean()
+            mae_val  = mae.mean(dim=sdims).mean()
+            asym_val = asym.mean(dim=sdims).mean()
+
+        if is_main_process() and (call_state["n"] % 50 == 0):
+            logger.info(
+                " >> >> [asym_doury] step %d: mae=%.6e asym=%.6e total=%.6e",
+                call_state["n"],
+                mae_val.item(),
+                asym_val.item(),
+                loss.item(),
+            )
+
+        return loss
+
+    return loss_fn
+#====================================================================
 def get_sde_loss_fn(sde, train, reduce_mean=True, continuous=True, likelihood_weighting=True, eps=1e-5):
     """Create a loss function for training with arbirary SDEs.
 
@@ -303,13 +575,80 @@ def get_loss(sde, train, config):
 
             logger.info("[[[[[[[[[[[[[[[[[[[[[[[ WMSE MS-SSIM ]]]]]]]]]]]]]]]]]]]]]]]")
 
-
             assert config.data.predictands.target_transform_keys[0] == "none", f"config.data.target_transform_key must be 'none', Got {config.data.predictands.target_transform_keys}"
             loss_fn = get_deterministic_loss_fn_wmse_msssim(train,
                                                             reduce_mean=config.training.reduce_mean,
                                                             alpha=config.training.wmse_ms_ssim_alpha,
                                                             beta=config.training.wmse_ms_ssim_beta,
-                                                            lam=config.training.wmse_ms_ssim_lam) 
+                                                            lam=config.training.wmse_ms_ssim_lam)
+
+        elif config.training.det_loss_type == 'ASYM':
+
+            logger.info("[[[[[[[[[[[[[[[[[[[[[[[ ASYM (Doury et al. 2024) ]]]]]]]]]]]]]]]]]]]]]]]")
+
+            assert config.data.predictands.target_transform_keys[0] == "none", (
+                f"ASYM loss requires physical-unit targets (target_transform_keys must be 'none'). "
+                f"Got {config.data.predictands.target_transform_keys}"
+            )
+
+            # --- Determine training filename ---
+            # If asym_train_filename is not set, fall back to FLAGS.filename
+            # (the same zarr used for ML training), so no extra config is needed.
+            asym_train_filename = getattr(config.training, 'asym_train_filename', '')
+            if not asym_train_filename:
+                from absl import flags as _absl_flags
+                asym_train_filename = _absl_flags.FLAGS.filename
+                logger.info(
+                    "[get_loss/ASYM] asym_train_filename not set; "
+                    "using ML training file: %s", asym_train_filename
+                )
+
+            # --- Auto-construct gamma params path ---
+            # $WORK_DIR/doury_gamma_params/<dataset_name>/<train_stem>/parameters.npz
+            work_dir    = os.getenv('WORK_DIR', os.getenv('DERIVED_DATA', '.'))
+            train_stem  = Path(asym_train_filename).stem
+            params_path = (
+                Path(work_dir)
+                / 'doury_gamma_params'
+                / config.data.dataset_name
+                / train_stem
+                / 'parameters.npz'
+            )
+            logger.info("[get_loss/ASYM] gamma params path: %s", params_path)
+
+            # --- Cache check: skip fitting if params already exist ---
+            if params_path.exists():
+                logger.info("[get_loss/ASYM] Loading cached gamma params from %s", params_path)
+                npz         = np.load(params_path)
+                gamma_shape = npz['shape']
+                gamma_scale = npz['scale']
+            else:
+                logger.info("[get_loss/ASYM] Fitting gamma params from %s", asym_train_filename)
+                import xarray as xr
+                derived_data = os.getenv('DERIVED_DATA', '.')
+                zarr_path    = os.path.join(derived_data, config.data.dataset_name, asym_train_filename)
+                ds           = xr.open_zarr(zarr_path)
+                precip_var   = config.data.predictands.variables[0]
+                precip_da    = ds[precip_var]
+
+                gamma_shape, gamma_scale = fit_gamma_params_per_gridpoint(
+                    precip_da,
+                    rain_threshold=config.training.asym_rain_threshold,
+                    lat_chunk=config.training.asym_lat_chunk,
+                    lon_chunk=config.training.asym_lon_chunk,
+                )
+                params_path.parent.mkdir(parents=True, exist_ok=True)
+                np.savez(params_path, shape=gamma_shape, scale=gamma_scale)
+                logger.info("[get_loss/ASYM] Saved gamma params to %s", params_path)
+
+            loss_fn = get_deterministic_loss_fn_asym_doury(
+                train,
+                gamma_shape=gamma_shape,
+                gamma_scale=gamma_scale,
+                rain_threshold=config.training.asym_rain_threshold,
+                reduce_mean=config.training.reduce_mean,
+            )
+
         else:
             logger.info("[[[[[[[[[[[[[[[[[[[[[[[ regular MSE ]]]]]]]]]]]]]]]]]]]]]]]")
             loss_fn = get_deterministic_loss_fn(train, reduce_mean=config.training.reduce_mean)


### PR DESCRIPTION
Implements the full ASYM loss (Doury et al. 2024, Eq. 4) for the deterministic model. Key behaviour: if asym_train_filename is left empty (the default), get_loss() reads FLAGS.filename so the gamma distribution is fitted on the same zarr used for ML training — no extra config required.

- fit_gamma_params_per_gridpoint: xarray/dask LocalCluster, tqdm bars
- get_deterministic_loss_fn_asym_doury: Doury Eq. 4, device-cached tensors
- get_loss(): ASYM branch with auto path, cache check, FLAGS.filename fallback
- default_josh_config.py: asym_train_filename, asym_rain_threshold, asym_lat_chunk, asym_lon_chunk